### PR TITLE
fix: Duplicate Dos & Don't slide(58 & 59)

### DIFF
--- a/pages/interaction.md
+++ b/pages/interaction.md
@@ -181,33 +181,6 @@ transition: slide-left
 name: Dos and Don'ts
 ---
 
-[Dos]{.text-gradient.text-4xl} [and]{.text-4xl} [Don'ts]{.text-gradient.text-4xl}
-
-[Dos:]{.text-green-400.underline}
-
-- <u>Use Arrow Functions for Simplicity:</u> Especially when you need to pass arguments to the event handler.
-
-```jsx
-<button onClick={() => handleClick(item.id)}>Click me</button>
-```
-
-- <u>Use `event.preventDefault()`:</u> When you want to prevent the default behavior of events like form submissions or link clicks.
-
-```jsx
-function handleSubmit(event) {
-  event.preventDefault()
-  // Handle form submission logic
-}
-```
-
-- <u>Keep Event Handlers Small:</u> If your event handler logic grows too large, consider moving it into a separate function for better readability.
-
----
-hideInToc: true
-transition: slide-left
-name: Dos and Don'ts
----
-
 # [Dos]{.text-gradient} and [Don'ts]{.text-gradient}
 
 [Don'ts:]{.text-red.underline}
@@ -295,7 +268,7 @@ function UserList({ users, onSelectUser }) {
 ```jsx {*|3-5,12|*}
 // Do
 function UserList({ users, onSelectUser }) {
-  const handleSelectUser = (id) => () => {
+  const handleSelectUser = (id) => {
     onSelectUser(id)
   } // Define the function outside of the map and pass it to the child elements
 


### PR DESCRIPTION
- Remove duplicate Dos and Don'ts slides (slides 58 and 59)
- Fix syntax in handleSelectUser function (remove double parentheses and arrow on slide 61)